### PR TITLE
Potential fix for code scanning alert no. 47: Type confusion through …

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,18 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    const rawCriteria: any = req.query.q
+    let criteria: string
+    if (Array.isArray(rawCriteria)) {
+      const first = rawCriteria.find((v: any) => typeof v === 'string') as string | undefined
+      criteria = first ?? ''
+    } else if (typeof rawCriteria === 'string') {
+      criteria = rawCriteria === 'undefined' ? '' : rawCriteria
+    } else if (rawCriteria == null) {
+      criteria = ''
+    } else {
+      criteria = String(rawCriteria)
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
…parameter tampering

<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-days or even
∞ ban from interacting with the project depending on reoccurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
