### PR TITLE
Update lint-fixer workflow to remove push trigger

### DIFF
--- a/.github/workflows/lint-fixer.yml
+++ b/.github/workflows/lint-fixer.yml
@@ -1,10 +1,5 @@
 name: "Let me lint:fix that for you"
 
-on:
- push:
-    branches:
-    - development
-
 jobs:
   LMLFTFY:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed the push trigger for the lint-fixer workflow.

<!--

Our Org Uses a Pull Request Template! 
-->

### Description

<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

