### PR TITLE
Potential fix for code scanning alert no. 12: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/theBadSoftwareClub/Juice-Shop/security/code-scanning/12](https://github.com/theBadSoftwareClub/Juice-Shop/security/code-scanning/12)

The best fix is to stop using `$where` entirely and use a normal field equality query, which does not evaluate user input as code.

In `routes/trackOrder.ts`, replace:

- `db.ordersCollection.find({ $where: \`this.orderId === '${id}'\` })`

with:

- `db.ordersCollection.find({ orderId: id })`

This preserves functional behavior (lookup by `orderId`) while removing the code execution sink. No new imports, helper methods, or dependencies are required. This single change addresses both alert variants because both point to the same tainted dynamic `$where` expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
